### PR TITLE
Only try to look up custom annotations if we have some.

### DIFF
--- a/definitions/tools/vep.wdl
+++ b/definitions/tools/vep.wdl
@@ -47,7 +47,7 @@ task vepTask {
     mkdir ~{cache_dir} && unzip -qq ~{cache_dir_zip} -d ~{cache_dir}
     #custom vep inputs (required files) get localized and we have to define this variable
     #pointing to their current path so that the custom string works as expected
-    custom_inputs_dir=$(dirname ~{required_files[0]})
+    ~{if length(required_files) > 0 then "custom_inputs_dir=$(dirname ~{required_files[0]})" else ""}
 
     /usr/bin/perl -I /opt/lib/perl/VEP/Plugins /usr/bin/variant_effect_predictor.pl \
     --format vcf \


### PR DESCRIPTION
`required_files` (despite the name) is the files that are required for the optional custom annotations.  If none were supplied there will be no entries in the array so we can't assume we will get a path.