### PR TITLE
Exposing Variant Filtering Params

### DIFF
--- a/definitions/detect_variants.wdl
+++ b/definitions/detect_variants.wdl
@@ -41,7 +41,6 @@ workflow detectVariants {
     Float varscan_min_var_freq = 0.1
     Float varscan_p_value = 0.99
     Float? varscan_max_normal_freq
-    Float? min_var_freq = varscan_min_var_freq
 
     File docm_vcf
     File docm_vcf_tbi
@@ -121,7 +120,7 @@ workflow detectVariants {
     scatter_count=scatter_count,
     strand_filter=varscan_strand_filter,
     min_coverage=varscan_min_coverage,
-    min_var_freq=min_var_freq,
+    min_var_freq=varscan_min_var_freq,
     p_value=varscan_p_value,
     max_normal_freq=varscan_max_normal_freq,
     normal_sample_name=normal_sample_name,

--- a/definitions/detect_variants.wdl
+++ b/definitions/detect_variants.wdl
@@ -42,6 +42,8 @@ workflow detectVariants {
     Float varscan_p_value = 0.99
     Float? varscan_max_normal_freq
 
+    Float? min_var_freq = varscan_min_var_freq
+
     File docm_vcf
     File docm_vcf_tbi
 
@@ -88,7 +90,8 @@ workflow detectVariants {
     normal_bam=normal_bam,
     normal_bam_bai=normal_bam_bai,
     interval_list=roi_intervals,
-    scatter_count=scatter_count
+    scatter_count=scatter_count,
+    min_var_freq=min_var_freq
   }
 
   call sapp.strelkaAndPostProcessing as strelka {
@@ -104,7 +107,8 @@ workflow detectVariants {
     exome_mode=strelka_exome_mode,
     cpu_reserved=strelka_cpu_reserved,
     normal_sample_name=normal_sample_name,
-    tumor_sample_name=tumor_sample_name
+    tumor_sample_name=tumor_sample_name,
+    min_var_freq=min_var_freq
   }
 
   call vpapp.varscanPreAndPostProcessing as varscan {

--- a/definitions/detect_variants.wdl
+++ b/definitions/detect_variants.wdl
@@ -41,6 +41,7 @@ workflow detectVariants {
     Float varscan_min_var_freq = 0.1
     Float varscan_p_value = 0.99
     Float? varscan_max_normal_freq
+    Float? min_var_freq = varscan_min_var_freq
 
     File docm_vcf
     File docm_vcf_tbi
@@ -120,7 +121,7 @@ workflow detectVariants {
     scatter_count=scatter_count,
     strand_filter=varscan_strand_filter,
     min_coverage=varscan_min_coverage,
-    min_var_freq=varscan_min_var_freq,
+    min_var_freq=min_var_freq,
     p_value=varscan_p_value,
     max_normal_freq=varscan_max_normal_freq,
     normal_sample_name=normal_sample_name,

--- a/definitions/detect_variants.wdl
+++ b/definitions/detect_variants.wdl
@@ -42,7 +42,7 @@ workflow detectVariants {
     Float varscan_p_value = 0.99
     Float? varscan_max_normal_freq
 
-    Float? min_var_freq = varscan_min_var_freq
+    Float? min_var_freq
 
     File docm_vcf
     File docm_vcf_tbi

--- a/definitions/immuno.wdl
+++ b/definitions/immuno.wdl
@@ -143,7 +143,7 @@ workflow immuno {
     Float varscan_p_value = 0.99
     Float? varscan_max_normal_freq
     Float? filter_somatic_llr_threshold
-    Float? min_var_freq = .05
+    Float? min_var_freq = .05 # used for strelka and mutect
 
     File docm_vcf
     File docm_vcf_tbi

--- a/definitions/immuno.wdl
+++ b/definitions/immuno.wdl
@@ -143,6 +143,7 @@ workflow immuno {
     Float varscan_p_value = 0.99
     Float? varscan_max_normal_freq
     Float? filter_somatic_llr_threshold
+    Float? min_var_freq = .05
 
     File docm_vcf
     File docm_vcf_tbi
@@ -278,6 +279,7 @@ workflow immuno {
     varscan_strand_filter=varscan_strand_filter,
     varscan_min_coverage=varscan_min_coverage,
     varscan_min_var_freq=varscan_min_var_freq,
+    min_var_freq=min_var_freq,
     varscan_p_value=varscan_p_value,
     varscan_max_normal_freq=varscan_max_normal_freq,
     filter_somatic_llr_threshold=filter_somatic_llr_threshold,

--- a/definitions/immuno.wdl
+++ b/definitions/immuno.wdl
@@ -143,7 +143,7 @@ workflow immuno {
     Float varscan_p_value = 0.99
     Float? varscan_max_normal_freq
     Float? filter_somatic_llr_threshold
-    Float? min_var_freq = 0.05 # used for strelka and mutect
+    Float? min_var_freq # used for strelka and mutect
 
     File docm_vcf
     File docm_vcf_tbi

--- a/definitions/immuno.wdl
+++ b/definitions/immuno.wdl
@@ -143,7 +143,7 @@ workflow immuno {
     Float varscan_p_value = 0.99
     Float? varscan_max_normal_freq
     Float? filter_somatic_llr_threshold
-    Float? min_var_freq = .05 # used for strelka and mutect
+    Float? min_var_freq = 0.05 # used for strelka and mutect
 
     File docm_vcf
     File docm_vcf_tbi

--- a/definitions/immuno.wdl
+++ b/definitions/immuno.wdl
@@ -142,10 +142,8 @@ workflow immuno {
     Float varscan_min_var_freq = 0.05
     Float varscan_p_value = 0.99
     Float? varscan_max_normal_freq
-    Float? min_var_freq
-
     Float? filter_somatic_llr_threshold
-    
+
     File docm_vcf
     File docm_vcf_tbi
 
@@ -280,7 +278,6 @@ workflow immuno {
     varscan_strand_filter=varscan_strand_filter,
     varscan_min_coverage=varscan_min_coverage,
     varscan_min_var_freq=varscan_min_var_freq,
-    min_var_freq=min_var_freq,
     varscan_p_value=varscan_p_value,
     varscan_max_normal_freq=varscan_max_normal_freq,
     filter_somatic_llr_threshold=filter_somatic_llr_threshold,

--- a/definitions/immuno.wdl
+++ b/definitions/immuno.wdl
@@ -142,7 +142,10 @@ workflow immuno {
     Float varscan_min_var_freq = 0.05
     Float varscan_p_value = 0.99
     Float? varscan_max_normal_freq
+    Float? min_var_freq
 
+    Float? filter_somatic_llr_threshold
+    
     File docm_vcf
     File docm_vcf_tbi
 
@@ -277,8 +280,10 @@ workflow immuno {
     varscan_strand_filter=varscan_strand_filter,
     varscan_min_coverage=varscan_min_coverage,
     varscan_min_var_freq=varscan_min_var_freq,
+    min_var_freq=min_var_freq,
     varscan_p_value=varscan_p_value,
     varscan_max_normal_freq=varscan_max_normal_freq,
+    filter_somatic_llr_threshold=filter_somatic_llr_threshold,
     docm_vcf=docm_vcf,
     docm_vcf_tbi=docm_vcf_tbi,
     filter_docm_variants=filter_docm_variants,

--- a/definitions/somatic_exome.wdl
+++ b/definitions/somatic_exome.wdl
@@ -61,7 +61,6 @@ workflow somaticExome {
     Float varscan_min_var_freq = 0.05
     Float varscan_p_value = 0.99
     Float? varscan_max_normal_freq
-    Float? min_var_freq = varsan_min_var_freq
 
     File docm_vcf
     File docm_vcf_tbi
@@ -205,7 +204,6 @@ workflow somaticExome {
     varscan_strand_filter=varscan_strand_filter,
     varscan_min_coverage=varscan_min_coverage,
     varscan_min_var_freq=varscan_min_var_freq,
-    min_var_freq=min_var_freq,
     varscan_p_value=varscan_p_value,
     varscan_max_normal_freq=varscan_max_normal_freq,
     docm_vcf=docm_vcf,

--- a/definitions/somatic_exome.wdl
+++ b/definitions/somatic_exome.wdl
@@ -61,6 +61,7 @@ workflow somaticExome {
     Float varscan_min_var_freq = 0.05
     Float varscan_p_value = 0.99
     Float? varscan_max_normal_freq
+    Float? min_var_freq = varsan_min_var_freq
 
     File docm_vcf
     File docm_vcf_tbi
@@ -204,6 +205,7 @@ workflow somaticExome {
     varscan_strand_filter=varscan_strand_filter,
     varscan_min_coverage=varscan_min_coverage,
     varscan_min_var_freq=varscan_min_var_freq,
+    min_var_freq=min_var_freq,
     varscan_p_value=varscan_p_value,
     varscan_max_normal_freq=varscan_max_normal_freq,
     docm_vcf=docm_vcf,

--- a/definitions/somatic_exome.wdl
+++ b/definitions/somatic_exome.wdl
@@ -61,7 +61,7 @@ workflow somaticExome {
     Float varscan_min_var_freq = 0.05
     Float varscan_p_value = 0.99
     Float? varscan_max_normal_freq
-    Float? min_var_freq = varscan_min_var_freq
+    Float? min_var_freq
 
     File docm_vcf
     File docm_vcf_tbi

--- a/definitions/somatic_exome.wdl
+++ b/definitions/somatic_exome.wdl
@@ -61,6 +61,7 @@ workflow somaticExome {
     Float varscan_min_var_freq = 0.05
     Float varscan_p_value = 0.99
     Float? varscan_max_normal_freq
+    Float? min_var_freq = varscan_min_var_freq
 
     File docm_vcf
     File docm_vcf_tbi
@@ -204,6 +205,7 @@ workflow somaticExome {
     varscan_strand_filter=varscan_strand_filter,
     varscan_min_coverage=varscan_min_coverage,
     varscan_min_var_freq=varscan_min_var_freq,
+    min_var_freq=min_var_freq,
     varscan_p_value=varscan_p_value,
     varscan_max_normal_freq=varscan_max_normal_freq,
     docm_vcf=docm_vcf,

--- a/definitions/subworkflows/mutect.wdl
+++ b/definitions/subworkflows/mutect.wdl
@@ -22,6 +22,8 @@ workflow mutect {
     File interval_list
     Int scatter_count
     String tumor_sample_name
+
+    Float? min_var_freq
   }
 
   call sil.splitIntervalList {
@@ -64,7 +66,8 @@ workflow mutect {
     vcf=indexVcf.indexed_vcf,
     vcf_tbi=indexVcf.indexed_vcf_tbi,
     variant_caller="mutect",
-    sample_name=tumor_sample_name
+    sample_name=tumor_sample_name,
+    min_var_freq=min_var_freq
   }
 
   output {

--- a/definitions/subworkflows/strelka_and_post_processing.wdl
+++ b/definitions/subworkflows/strelka_and_post_processing.wdl
@@ -29,6 +29,8 @@ workflow strelkaAndPostProcessing {
 
     File? call_regions
     File? call_regions_tbi
+
+    Float? min_var_freq
   }
 
   call s.strelka {
@@ -96,7 +98,8 @@ workflow strelkaAndPostProcessing {
     vcf=regionFilter.filtered_vcf,
     vcf_tbi=regionFilter.filtered_vcf_tbi,
     sample_name=tumor_sample_name,
-    variant_caller="strelka"
+    variant_caller="strelka",
+    min_var_freq=min_var_freq
   }
 
   output {


### PR DESCRIPTION
- [x] Tested 

Tumor VAF cutoff for FP filter applied to mutect and strelka calls can now be tuned at `immuno.wdl` level using `immuno.min_var_freq` in yaml.

`immuno.varscan_min_var_freq` is used specifically for varscan now.

`immuno.filter_somatic_llr_threshold` can be set at the level of `immuno.wdl` in yaml

