### PR TITLE
variant filtering parameter cleanup

### DIFF
--- a/definitions/detect_variants.wdl
+++ b/definitions/detect_variants.wdl
@@ -36,11 +36,13 @@ workflow detectVariants {
     Boolean strelka_exome_mode
     Int strelka_cpu_reserved = 8
 
-    Int varscan_strand_filter = 0
-    Int varscan_min_coverage = 8
-    Float varscan_min_var_freq = 0.1
-    Float varscan_p_value = 0.99
+    Int varscan_strand_filter
+    Int varscan_min_coverage
+    Float varscan_min_var_freq
+    Float varscan_p_value
     Float? varscan_max_normal_freq
+
+    Float fp_min_var_freq
 
     File docm_vcf
     File docm_vcf_tbi
@@ -88,7 +90,8 @@ workflow detectVariants {
     normal_bam=normal_bam,
     normal_bam_bai=normal_bam_bai,
     interval_list=roi_intervals,
-    scatter_count=scatter_count
+    scatter_count=scatter_count,
+    fp_min_var_freq=fp_min_var_freq
   }
 
   call sapp.strelkaAndPostProcessing as strelka {
@@ -104,7 +107,8 @@ workflow detectVariants {
     exome_mode=strelka_exome_mode,
     cpu_reserved=strelka_cpu_reserved,
     normal_sample_name=normal_sample_name,
-    tumor_sample_name=tumor_sample_name
+    tumor_sample_name=tumor_sample_name,
+    fp_min_var_freq=fp_min_var_freq
   }
 
   call vpapp.varscanPreAndPostProcessing as varscan {
@@ -120,9 +124,10 @@ workflow detectVariants {
     scatter_count=scatter_count,
     strand_filter=varscan_strand_filter,
     min_coverage=varscan_min_coverage,
-    min_var_freq=varscan_min_var_freq,
+    varscan_min_var_freq=varscan_min_var_freq,
     p_value=varscan_p_value,
     max_normal_freq=varscan_max_normal_freq,
+    fp_min_var_freq=fp_min_var_freq,
     normal_sample_name=normal_sample_name,
     tumor_sample_name=tumor_sample_name
   }

--- a/definitions/detect_variants.wdl
+++ b/definitions/detect_variants.wdl
@@ -127,7 +127,6 @@ workflow detectVariants {
     varscan_min_var_freq=varscan_min_var_freq,
     p_value=varscan_p_value,
     max_normal_freq=varscan_max_normal_freq,
-    fp_min_var_freq=fp_min_var_freq,
     normal_sample_name=normal_sample_name,
     tumor_sample_name=tumor_sample_name
   }

--- a/definitions/detect_variants.wdl
+++ b/definitions/detect_variants.wdl
@@ -66,9 +66,9 @@ workflow detectVariants {
     String gnomad_field_name = "gnomADe_AF"  # only change with gnomad_filter annotation
     Float filter_gnomADe_maximum_population_allele_frequency = 0.001
     Float filter_mapq0_threshold = 0.15
-    Float filter_somatic_llr_threshold = 5
-    Float filter_somatic_llr_tumor_purity = 1
-    Float filter_somatic_llr_normal_contamination_rate = 0
+    Float filter_somatic_llr_threshold
+    Float filter_somatic_llr_tumor_purity
+    Float filter_somatic_llr_normal_contamination_rate
     Int filter_minimum_depth = 1
     Boolean cle_vcf_filter = false
     Array[String] variants_to_table_fields = ["CHROM", "POS", "ID", "REF", "ALT", "set", "AC", "AF"]

--- a/definitions/detect_variants.wdl
+++ b/definitions/detect_variants.wdl
@@ -36,13 +36,13 @@ workflow detectVariants {
     Boolean strelka_exome_mode
     Int strelka_cpu_reserved = 8
 
-    Int varscan_strand_filter
-    Int varscan_min_coverage
-    Float varscan_min_var_freq
-    Float varscan_p_value
+    Int? varscan_strand_filter
+    Int? varscan_min_coverage
+    Float? varscan_min_var_freq
+    Float? varscan_p_value
     Float? varscan_max_normal_freq
 
-    Float fp_min_var_freq
+    Float? fp_min_var_freq
 
     File docm_vcf
     File docm_vcf_tbi
@@ -66,9 +66,9 @@ workflow detectVariants {
     String gnomad_field_name = "gnomADe_AF"  # only change with gnomad_filter annotation
     Float filter_gnomADe_maximum_population_allele_frequency = 0.001
     Float filter_mapq0_threshold = 0.15
-    Float filter_somatic_llr_threshold
-    Float filter_somatic_llr_tumor_purity
-    Float filter_somatic_llr_normal_contamination_rate
+    Float? filter_somatic_llr_threshold
+    Float? filter_somatic_llr_tumor_purity
+    Float? filter_somatic_llr_normal_contamination_rate
     Int filter_minimum_depth = 1
     Boolean cle_vcf_filter = false
     Array[String] variants_to_table_fields = ["CHROM", "POS", "ID", "REF", "ALT", "set", "AC", "AF"]

--- a/definitions/detect_variants_nonhuman.wdl
+++ b/definitions/detect_variants_nonhuman.wdl
@@ -33,13 +33,13 @@ workflow detectVariantsNonhuman {
     Boolean strelka_exome_mode
     Int strelka_cpu_reserved = 8
 
-    Int varscan_strand_filter
-    Int varscan_min_coverage
-    Float varscan_min_var_freq
-    Float varscan_p_value
+    Int? varscan_strand_filter
+    Int? varscan_min_coverage
+    Float? varscan_min_var_freq
+    Float? varscan_p_value
     Float? varscan_max_normal_freq
 
-    Float fp_min_var_freq
+    Float? fp_min_var_freq
 
     File vep_cache_dir_zip
     String vep_ensembl_assembly
@@ -55,9 +55,9 @@ workflow detectVariantsNonhuman {
     Int? readcount_minimum_mapping_quality
 
     Float filter_mapq0_threshold = 0.15
-    Float filter_somatic_llr_threshold = 5
-    Float filter_somatic_llr_tumor_purity = 1
-    Float filter_somatic_llr_normal_contamination_rate = 0
+    Float? filter_somatic_llr_threshold
+    Float? filter_somatic_llr_tumor_purity
+    Float? filter_somatic_llr_normal_contamination_rate
     Int filter_minimum_depth = 1
     Boolean cle_vcf_filter = false
     Array[String] variants_to_table_fields = ["CHROM", "POS", "ID", "REF", "ALT", "set", "AC", "AF"]

--- a/definitions/detect_variants_nonhuman.wdl
+++ b/definitions/detect_variants_nonhuman.wdl
@@ -33,11 +33,13 @@ workflow detectVariantsNonhuman {
     Boolean strelka_exome_mode
     Int strelka_cpu_reserved = 8
 
-    Int varscan_strand_filter = 0
-    Int varscan_min_coverage = 8
-    Float varscan_min_var_freq = 0.1
-    Float varscan_p_value = 0.99
+    Int varscan_strand_filter
+    Int varscan_min_coverage
+    Float varscan_min_var_freq
+    Float varscan_p_value
     Float? varscan_max_normal_freq
+
+    Float fp_min_var_freq
 
     File vep_cache_dir_zip
     String vep_ensembl_assembly
@@ -74,7 +76,8 @@ workflow detectVariantsNonhuman {
     normal_bam=normal_bam,
     normal_bam_bai=normal_bam_bai,
     interval_list=roi_intervals,
-    scatter_count=scatter_count
+    scatter_count=scatter_count,
+    fp_min_var_freq=fp_min_var_freq
   }
 
   call sapp.strelkaAndPostProcessing as strelka {
@@ -90,7 +93,8 @@ workflow detectVariantsNonhuman {
     exome_mode=strelka_exome_mode,
     cpu_reserved=strelka_cpu_reserved,
     normal_sample_name=normal_sample_name,
-    tumor_sample_name=normal_sample_name
+    tumor_sample_name=normal_sample_name,
+    fp_min_var_freq=fp_min_var_freq
   }
 
   call vpapp.varscanPreAndPostProcessing as varscan {
@@ -106,9 +110,10 @@ workflow detectVariantsNonhuman {
     scatter_count=scatter_count,
     strand_filter=varscan_strand_filter,
     min_coverage=varscan_min_coverage,
-    min_var_freq=varscan_min_var_freq,
+    varscan_min_var_freq=varscan_min_var_freq,
     p_value=varscan_p_value,
     max_normal_freq=varscan_max_normal_freq,
+    fp_min_var_freq=fp_min_var_freq,
     normal_sample_name=normal_sample_name,
     tumor_sample_name=tumor_sample_name
   }

--- a/definitions/detect_variants_nonhuman.wdl
+++ b/definitions/detect_variants_nonhuman.wdl
@@ -113,7 +113,6 @@ workflow detectVariantsNonhuman {
     varscan_min_var_freq=varscan_min_var_freq,
     p_value=varscan_p_value,
     max_normal_freq=varscan_max_normal_freq,
-    fp_min_var_freq=fp_min_var_freq,
     normal_sample_name=normal_sample_name,
     tumor_sample_name=tumor_sample_name
   }

--- a/definitions/detect_variants_wgs.wdl
+++ b/definitions/detect_variants_wgs.wdl
@@ -34,11 +34,12 @@ workflow detectVariantsWgs {
     Int? readcount_minimum_base_quality
     Int? readcount_minimum_mapping_quality
     Int scatter_count
-    Int varscan_strand_filter = 0
-    Int varscan_min_coverage = 8
-    Float varscan_min_var_freq = 0.1
-    Float varscan_p_value = 0.99
+    Int varscan_strand_filter
+    Int varscan_min_coverage
+    Float varscan_min_var_freq
+    Float varscan_p_value
     Float? varscan_max_normal_freq
+    Float fp_min_var_freq
     File docm_vcf
     File docm_vcf_tbi
     Boolean filter_docm_variants = true
@@ -80,7 +81,8 @@ workflow detectVariantsWgs {
     normal_bam_bai=normal_bam_bai,
     interval_list=roi_intervals,
     scatter_count=scatter_count,
-    tumor_sample_name=tumor_sample_name
+    tumor_sample_name=tumor_sample_name,
+    fp_min_var_freq=fp_min_var_freq
   }
 
   call sapp.strelkaAndPostProcessing as strelka {
@@ -101,7 +103,8 @@ workflow detectVariantsWgs {
     exome_mode=strelka_exome_mode,
     cpu_reserved=strelka_cpu_reserved,
     call_regions=strelka_call_regions,
-    call_regions_tbi=strelka_call_regions_tbi
+    call_regions_tbi=strelka_call_regions_tbi,
+    fp_min_var_freq=fp_min_var_freq
   }
 
   call vpapp.varscanPreAndPostProcessing as varscan {
@@ -122,9 +125,10 @@ workflow detectVariantsWgs {
     scatter_count=scatter_count,
     strand_filter=varscan_strand_filter,
     min_coverage=varscan_min_coverage,
-    min_var_freq=varscan_min_var_freq,
+    varscan_min_var_freq=varscan_min_var_freq,
     p_value=varscan_p_value,
-    max_normal_freq=varscan_max_normal_freq
+    max_normal_freq=varscan_max_normal_freq,
+    fp_min_var_freq=fp_min_var_freq
   }
 
   call dc.docmCle as docm {

--- a/definitions/detect_variants_wgs.wdl
+++ b/definitions/detect_variants_wgs.wdl
@@ -56,9 +56,9 @@ workflow detectVariantsWgs {
     Float filter_gnomADe_maximum_population_allele_frequency = 0.001
     Float filter_mapq0_threshold = 0.15
     Int filter_minimum_depth = 1
-    Float filter_somatic_llr_threshold = 5
-    Float filter_somatic_llr_tumor_purity = 1
-    Float filter_somatic_llr_normal_contamination_rate = 0
+    Float filter_somatic_llr_threshold
+    Float filter_somatic_llr_tumor_purity
+    Float filter_somatic_llr_normal_contamination_rate
     Boolean cle_vcf_filter = false
     Array[String] variants_to_table_fields = ["CHROM", "POS", "ID", "REF", "ALT", "set", "AC", "AF"]
     Array[String] variants_to_table_genotype_fields = ["GT", "AD"]

--- a/definitions/detect_variants_wgs.wdl
+++ b/definitions/detect_variants_wgs.wdl
@@ -127,8 +127,7 @@ workflow detectVariantsWgs {
     min_coverage=varscan_min_coverage,
     varscan_min_var_freq=varscan_min_var_freq,
     p_value=varscan_p_value,
-    max_normal_freq=varscan_max_normal_freq,
-    fp_min_var_freq=fp_min_var_freq
+    max_normal_freq=varscan_max_normal_freq
   }
 
   call dc.docmCle as docm {

--- a/definitions/detect_variants_wgs.wdl
+++ b/definitions/detect_variants_wgs.wdl
@@ -34,12 +34,12 @@ workflow detectVariantsWgs {
     Int? readcount_minimum_base_quality
     Int? readcount_minimum_mapping_quality
     Int scatter_count
-    Int varscan_strand_filter
-    Int varscan_min_coverage
-    Float varscan_min_var_freq
-    Float varscan_p_value
+    Int? varscan_strand_filter
+    Int? varscan_min_coverage
+    Float? varscan_min_var_freq
+    Float? varscan_p_value
     Float? varscan_max_normal_freq
-    Float fp_min_var_freq
+    Float? fp_min_var_freq
     File docm_vcf
     File docm_vcf_tbi
     Boolean filter_docm_variants = true
@@ -56,9 +56,9 @@ workflow detectVariantsWgs {
     Float filter_gnomADe_maximum_population_allele_frequency = 0.001
     Float filter_mapq0_threshold = 0.15
     Int filter_minimum_depth = 1
-    Float filter_somatic_llr_threshold
-    Float filter_somatic_llr_tumor_purity
-    Float filter_somatic_llr_normal_contamination_rate
+    Float? filter_somatic_llr_threshold
+    Float? filter_somatic_llr_tumor_purity
+    Float? filter_somatic_llr_normal_contamination_rate
     Boolean cle_vcf_filter = false
     Array[String] variants_to_table_fields = ["CHROM", "POS", "ID", "REF", "ALT", "set", "AC", "AF"]
     Array[String] variants_to_table_genotype_fields = ["GT", "AD"]

--- a/definitions/immuno.wdl
+++ b/definitions/immuno.wdl
@@ -180,6 +180,11 @@ workflow immuno {
     # one of [pick, flag_pick, pick-allele, per_gene, pick_allele_gene, flag_pick_allele, flag_pick_allele_gene]
     String? vep_pick
     Boolean cle_vcf_filter = false
+    
+    Float filter_somatic_llr_threshold
+    Float filter_somatic_llr_tumor_purity
+    Float filter_somatic_llr_normal_contamination_rate
+
     Array[String] vep_to_table_fields = ["HGVSc", "HGVSp"]
     Array[String] variants_to_table_genotype_fields = ["GT", "AD"]
     Array[String] variants_to_table_fields = ["CHROM", "POS", "ID", "REF", "ALT", "set", "AC", "AF"]
@@ -336,6 +341,9 @@ workflow immuno {
     annotate_coding_only=annotate_coding_only,
     vep_pick=vep_pick,
     cle_vcf_filter=cle_vcf_filter,
+    filter_somatic_llr_threshold=filter_somatic_llr_threshold,
+    filter_somatic_llr_tumor_purity=filter_somatic_llr_tumor_purity,
+    filter_somatic_llr_normal_contamination_rate=filter_somatic_llr_normal_contamination_rate,
     variants_to_table_fields=variants_to_table_fields,
     variants_to_table_genotype_fields=variants_to_table_genotype_fields,
     vep_to_table_fields=vep_to_table_fields,

--- a/definitions/immuno.wdl
+++ b/definitions/immuno.wdl
@@ -157,11 +157,13 @@ workflow immuno {
     Int strelka_cpu_reserved = 8
     Int scatter_count = 50
 
-    Int varscan_strand_filter = 0
-    Int varscan_min_coverage = 8
-    Float varscan_min_var_freq = 0.05
-    Float varscan_p_value = 0.99
+    Int varscan_strand_filter
+    Int varscan_min_coverage
+    Float varscan_min_var_freq
+    Float varscan_p_value
     Float? varscan_max_normal_freq
+
+    Float fp_min_var_freq
 
     File docm_vcf
     File docm_vcf_tbi
@@ -322,6 +324,7 @@ workflow immuno {
     varscan_min_var_freq=varscan_min_var_freq,
     varscan_p_value=varscan_p_value,
     varscan_max_normal_freq=varscan_max_normal_freq,
+    fp_min_var_freq=fp_min_var_freq,
     docm_vcf=docm_vcf,
     docm_vcf_tbi=docm_vcf_tbi,
     filter_docm_variants=filter_docm_variants,

--- a/definitions/immuno.wdl
+++ b/definitions/immuno.wdl
@@ -157,13 +157,13 @@ workflow immuno {
     Int strelka_cpu_reserved = 8
     Int scatter_count = 50
 
-    Int varscan_strand_filter
-    Int varscan_min_coverage
-    Float varscan_min_var_freq
-    Float varscan_p_value
+    Int? varscan_strand_filter
+    Int? varscan_min_coverage
+    Float? varscan_min_var_freq
+    Float? varscan_p_value
     Float? varscan_max_normal_freq
 
-    Float fp_min_var_freq
+    Float? fp_min_var_freq
 
     File docm_vcf
     File docm_vcf_tbi
@@ -181,9 +181,9 @@ workflow immuno {
     String? vep_pick
     Boolean cle_vcf_filter = false
     
-    Float filter_somatic_llr_threshold
-    Float filter_somatic_llr_tumor_purity
-    Float filter_somatic_llr_normal_contamination_rate
+    Float? filter_somatic_llr_threshold
+    Float? filter_somatic_llr_tumor_purity
+    Float? filter_somatic_llr_normal_contamination_rate
 
     Array[String] vep_to_table_fields = ["HGVSc", "HGVSp"]
     Array[String] variants_to_table_genotype_fields = ["GT", "AD"]

--- a/definitions/somatic_exome.wdl
+++ b/definitions/somatic_exome.wdl
@@ -56,13 +56,13 @@ workflow somaticExome {
     Int strelka_cpu_reserved = 8
     Int scatter_count = 50
 
-    Int varscan_strand_filter
-    Int varscan_min_coverage
-    Float varscan_min_var_freq
-    Float varscan_p_value
+    Int? varscan_strand_filter
+    Int? varscan_min_coverage
+    Float? varscan_min_var_freq
+    Float? varscan_p_value
     Float? varscan_max_normal_freq
 
-    Float fp_min_var_freq
+    Float? fp_min_var_freq
 
     File docm_vcf
     File docm_vcf_tbi
@@ -70,9 +70,9 @@ workflow somaticExome {
     Boolean filter_docm_variants = true
 
     String? gnomad_field_name
-    Float filter_somatic_llr_threshold
-    Float filter_somatic_llr_tumor_purity
-    Float filter_somatic_llr_normal_contamination_rate
+    Float? filter_somatic_llr_threshold
+    Float? filter_somatic_llr_tumor_purity
+    Float? filter_somatic_llr_normal_contamination_rate
 
     File vep_cache_dir_zip
     String vep_ensembl_assembly

--- a/definitions/somatic_exome.wdl
+++ b/definitions/somatic_exome.wdl
@@ -56,11 +56,13 @@ workflow somaticExome {
     Int strelka_cpu_reserved = 8
     Int scatter_count = 50
 
-    Int varscan_strand_filter = 0
-    Int varscan_min_coverage = 8
-    Float varscan_min_var_freq = 0.05
-    Float varscan_p_value = 0.99
+    Int varscan_strand_filter
+    Int varscan_min_coverage
+    Float varscan_min_var_freq
+    Float varscan_p_value
     Float? varscan_max_normal_freq
+
+    Float fp_min_var_freq
 
     File docm_vcf
     File docm_vcf_tbi
@@ -206,6 +208,7 @@ workflow somaticExome {
     varscan_min_var_freq=varscan_min_var_freq,
     varscan_p_value=varscan_p_value,
     varscan_max_normal_freq=varscan_max_normal_freq,
+    fp_min_var_freq=fp_min_var_freq,
     docm_vcf=docm_vcf,
     docm_vcf_tbi=docm_vcf_tbi,
     gnomad_field_name=gnomad_field_name,

--- a/definitions/somatic_exome.wdl
+++ b/definitions/somatic_exome.wdl
@@ -70,9 +70,9 @@ workflow somaticExome {
     Boolean filter_docm_variants = true
 
     String? gnomad_field_name
-    Float filter_somatic_llr_threshold = 5
-    Float filter_somatic_llr_tumor_purity = 1
-    Float filter_somatic_llr_normal_contamination_rate = 0
+    Float filter_somatic_llr_threshold
+    Float filter_somatic_llr_tumor_purity
+    Float filter_somatic_llr_normal_contamination_rate
 
     File vep_cache_dir_zip
     String vep_ensembl_assembly

--- a/definitions/somatic_exome_cle.wdl
+++ b/definitions/somatic_exome_cle.wdl
@@ -57,9 +57,9 @@ workflow somaticExomeCle {
     String? gnomad_field_name
     Boolean filter_docm_variants = true
     Int filter_minimum_depth = 20
-    Float filter_somatic_llr_threshold = 5
-    Float filter_somatic_llr_tumor_purity = 1.0
-    Float filter_somatic_llr_normal_contamination_rate = 0.0
+    Float filter_somatic_llr_threshold
+    Float filter_somatic_llr_tumor_purity
+    Float filter_somatic_llr_normal_contamination_rate
     File vep_cache_dir_zip
     String vep_ensembl_assembly
     String vep_ensembl_version

--- a/definitions/somatic_exome_cle.wdl
+++ b/definitions/somatic_exome_cle.wdl
@@ -46,11 +46,12 @@ workflow somaticExomeCle {
     Int qc_minimum_base_quality = 0
     Int strelka_cpu_reserved = 8
     Int scatter_count
-    Int varscan_strand_filter = 0
-    Int varscan_min_coverage = 8
-    Float varscan_min_var_freq = 0.05
-    Float varscan_p_value = 0.99
+    Int varscan_strand_filter
+    Int varscan_min_coverage
+    Float varscan_min_var_freq
+    Float varscan_p_value
     Float? varscan_max_normal_freq
+    Float fp_min_var_freq
     File docm_vcf
     File docm_vcf_tbi
     String? gnomad_field_name
@@ -168,6 +169,7 @@ workflow somaticExomeCle {
     varscan_min_var_freq=varscan_min_var_freq,
     varscan_p_value=varscan_p_value,
     varscan_max_normal_freq=varscan_max_normal_freq,
+    fp_min_var_freq=fp_min_var_freq,
     docm_vcf=docm_vcf,
     docm_vcf_tbi=docm_vcf_tbi,
     gnomad_field_name=gnomad_field_name,

--- a/definitions/somatic_exome_cle.wdl
+++ b/definitions/somatic_exome_cle.wdl
@@ -46,20 +46,20 @@ workflow somaticExomeCle {
     Int qc_minimum_base_quality = 0
     Int strelka_cpu_reserved = 8
     Int scatter_count
-    Int varscan_strand_filter
-    Int varscan_min_coverage
-    Float varscan_min_var_freq
-    Float varscan_p_value
+    Int? varscan_strand_filter
+    Int? varscan_min_coverage
+    Float? varscan_min_var_freq
+    Float? varscan_p_value
     Float? varscan_max_normal_freq
-    Float fp_min_var_freq
+    Float? fp_min_var_freq
     File docm_vcf
     File docm_vcf_tbi
     String? gnomad_field_name
     Boolean filter_docm_variants = true
     Int filter_minimum_depth = 20
-    Float filter_somatic_llr_threshold
-    Float filter_somatic_llr_tumor_purity
-    Float filter_somatic_llr_normal_contamination_rate
+    Float? filter_somatic_llr_threshold
+    Float? filter_somatic_llr_tumor_purity
+    Float? filter_somatic_llr_normal_contamination_rate
     File vep_cache_dir_zip
     String vep_ensembl_assembly
     String vep_ensembl_version

--- a/definitions/somatic_exome_nonhuman.wdl
+++ b/definitions/somatic_exome_nonhuman.wdl
@@ -43,13 +43,13 @@ workflow somaticExomeNonhuman {
     Int strelka_cpu_reserved = 8
     Int scatter_count = 50
 
-    Int varscan_strand_filter
-    Int varscan_min_coverage
-    Float varscan_min_var_freq
-    Float varscan_p_value
+    Int? varscan_strand_filter
+    Int? varscan_min_coverage
+    Float? varscan_min_var_freq
+    Float? varscan_p_value
     Float? varscan_max_normal_freq
 
-    Float fp_min_var_freq
+    Float? fp_min_var_freq
 
     File vep_cache_dir_zip
     String vep_ensembl_assembly
@@ -61,9 +61,9 @@ workflow somaticExomeNonhuman {
     String? vep_pick
     Boolean cle_vcf_filter = false
 
-    Float filter_somatic_llr_threshold
-    Float filter_somatic_llr_tumor_purity
-    Float filter_somatic_llr_normal_contamination_rate
+    Float? filter_somatic_llr_threshold
+    Float? filter_somatic_llr_tumor_purity
+    Float? filter_somatic_llr_normal_contamination_rate
 
     Array[String] vep_to_table_fields = ["Consequence", "SYMBOL", "Feature"]
     Array[String] variants_to_table_genotype_fields = ["GT", "AD"]

--- a/definitions/somatic_exome_nonhuman.wdl
+++ b/definitions/somatic_exome_nonhuman.wdl
@@ -43,11 +43,13 @@ workflow somaticExomeNonhuman {
     Int strelka_cpu_reserved = 8
     Int scatter_count = 50
 
-    Int varscan_strand_filter = 0
-    Int varscan_min_coverage = 8
-    Float varscan_min_var_freq = 0.1
-    Float varscan_p_value = 0.99
+    Int varscan_strand_filter
+    Int varscan_min_coverage
+    Float varscan_min_var_freq
+    Float varscan_p_value
     Float? varscan_max_normal_freq
+
+    Float fp_min_var_freq
 
     File vep_cache_dir_zip
     String vep_ensembl_assembly
@@ -142,6 +144,7 @@ workflow somaticExomeNonhuman {
     varscan_min_var_freq=varscan_min_var_freq,
     varscan_p_value=varscan_p_value,
     varscan_max_normal_freq=varscan_max_normal_freq,
+    fp_min_var_freq=fp_min_var_freq,
     filter_somatic_llr_threshold=filter_somatic_llr_threshold,
     filter_somatic_llr_tumor_purity=filter_somatic_llr_tumor_purity,
     filter_somatic_llr_normal_contamination_rate=filter_somatic_llr_normal_contamination_rate,

--- a/definitions/somatic_exome_nonhuman.wdl
+++ b/definitions/somatic_exome_nonhuman.wdl
@@ -61,9 +61,9 @@ workflow somaticExomeNonhuman {
     String? vep_pick
     Boolean cle_vcf_filter = false
 
-    Float filter_somatic_llr_threshold = 5
-    Float filter_somatic_llr_tumor_purity = 1
-    Float filter_somatic_llr_normal_contamination_rate = 0
+    Float filter_somatic_llr_threshold
+    Float filter_somatic_llr_tumor_purity
+    Float filter_somatic_llr_normal_contamination_rate
 
     Array[String] vep_to_table_fields = ["Consequence", "SYMBOL", "Feature"]
     Array[String] variants_to_table_genotype_fields = ["GT", "AD"]

--- a/definitions/somatic_wgs.wdl
+++ b/definitions/somatic_wgs.wdl
@@ -61,9 +61,9 @@ workflow somaticWgs {
     File docm_vcf_tbi
     Boolean filter_docm_variants = true
 
-    Float filter_somatic_llr_threshold = 5
-    Float filter_somatic_llr_tumor_purity = 1
-    Float filter_somatic_llr_normal_contamination_rate = 0
+    Float filter_somatic_llr_threshold
+    Float filter_somatic_llr_tumor_purity
+    Float filter_somatic_llr_normal_contamination_rate
     File vep_cache_dir_zip
     String vep_ensembl_assembly
     String vep_ensembl_version

--- a/definitions/somatic_wgs.wdl
+++ b/definitions/somatic_wgs.wdl
@@ -51,19 +51,19 @@ workflow somaticWgs {
     File? strelka_call_regions
     File? strelka_call_regions_tbi
     Int scatter_count
-    Int varscan_strand_filter
-    Int varscan_min_coverage
-    Float varscan_min_var_freq
-    Float varscan_p_value
+    Int? varscan_strand_filter
+    Int? varscan_min_coverage
+    Float? varscan_min_var_freq
+    Float? varscan_p_value
     Float? varscan_max_normal_freq
-    Float fp_min_var_freq
+    Float? fp_min_var_freq
     File docm_vcf
     File docm_vcf_tbi
     Boolean filter_docm_variants = true
 
-    Float filter_somatic_llr_threshold
-    Float filter_somatic_llr_tumor_purity
-    Float filter_somatic_llr_normal_contamination_rate
+    Float? filter_somatic_llr_threshold
+    Float? filter_somatic_llr_tumor_purity
+    Float? filter_somatic_llr_normal_contamination_rate
     File vep_cache_dir_zip
     String vep_ensembl_assembly
     String vep_ensembl_version

--- a/definitions/somatic_wgs.wdl
+++ b/definitions/somatic_wgs.wdl
@@ -51,15 +51,15 @@ workflow somaticWgs {
     File? strelka_call_regions
     File? strelka_call_regions_tbi
     Int scatter_count
-    Int varscan_strand_filter = 0
-    Int varscan_min_coverage = 8
-    Float varscan_min_var_freq = 0.05
-    Float varscan_p_value = 0.99
+    Int varscan_strand_filter
+    Int varscan_min_coverage
+    Float varscan_min_var_freq
+    Float varscan_p_value
     Float? varscan_max_normal_freq
+    Float fp_min_var_freq
     File docm_vcf
     File docm_vcf_tbi
     Boolean filter_docm_variants = true
-
 
     Float filter_somatic_llr_threshold = 5
     Float filter_somatic_llr_tumor_purity = 1
@@ -192,6 +192,7 @@ workflow somaticWgs {
     varscan_min_var_freq=varscan_min_var_freq,
     varscan_p_value=varscan_p_value,
     varscan_max_normal_freq=varscan_max_normal_freq,
+    fp_min_var_freq=fp_min_var_freq,
     docm_vcf=docm_vcf,
     docm_vcf_tbi=docm_vcf_tbi,
     filter_docm_variants=filter_docm_variants,

--- a/definitions/subworkflows/filter_vcf.wdl
+++ b/definitions/subworkflows/filter_vcf.wdl
@@ -18,9 +18,9 @@ workflow filterVcf {
     File tumor_bam
     File tumor_bam_bai
     Boolean do_cle_vcf_filter
-    Float filter_somatic_llr_threshold
-    Float filter_somatic_llr_tumor_purity
-    Float filter_somatic_llr_normal_contamination_rate
+    Float? filter_somatic_llr_threshold
+    Float? filter_somatic_llr_tumor_purity
+    Float? filter_somatic_llr_normal_contamination_rate
     File reference
     File reference_fai
     File reference_dict

--- a/definitions/subworkflows/filter_vcf_nonhuman.wdl
+++ b/definitions/subworkflows/filter_vcf_nonhuman.wdl
@@ -13,9 +13,9 @@ workflow filterVcfNonhuman {
     File tumor_bam
     File tumor_bam_bai
     Boolean do_cle_vcf_filter
-    Float filter_somatic_llr_threshold
-    Float filter_somatic_llr_tumor_purity
-    Float filter_somatic_llr_normal_contamination_rate
+    Float? filter_somatic_llr_threshold
+    Float? filter_somatic_llr_tumor_purity
+    Float? filter_somatic_llr_normal_contamination_rate
     File reference
     File reference_fai
     File reference_dict

--- a/definitions/subworkflows/fp_filter.wdl
+++ b/definitions/subworkflows/fp_filter.wdl
@@ -19,7 +19,7 @@ workflow fpFilter {
     File vcf_tbi
     String variant_caller
     String? sample_name
-    Float? min_var_freq
+    Float? fp_min_var_freq
   }
 
   call vs.vcfSanitize as sanitizeVcf {
@@ -53,7 +53,7 @@ workflow fpFilter {
     bam=bam,
     vcf=index.indexed_vcf,
     sample_name=sample_name,
-    min_var_freq=min_var_freq,
+    fp_min_var_freq=fp_min_var_freq,
     output_vcf_basename = variant_caller + "_full"
   }
 

--- a/definitions/subworkflows/mutect.wdl
+++ b/definitions/subworkflows/mutect.wdl
@@ -22,6 +22,7 @@ workflow mutect {
     File interval_list
     Int scatter_count
     String tumor_sample_name
+    Float fp_min_var_freq
   }
 
   call sil.splitIntervalList {
@@ -64,7 +65,8 @@ workflow mutect {
     vcf=indexVcf.indexed_vcf,
     vcf_tbi=indexVcf.indexed_vcf_tbi,
     variant_caller="mutect",
-    sample_name=tumor_sample_name
+    sample_name=tumor_sample_name,
+    fp_min_var_freq=fp_min_var_freq
   }
 
   output {

--- a/definitions/subworkflows/mutect.wdl
+++ b/definitions/subworkflows/mutect.wdl
@@ -22,7 +22,7 @@ workflow mutect {
     File interval_list
     Int scatter_count
     String tumor_sample_name
-    Float fp_min_var_freq
+    Float? fp_min_var_freq
   }
 
   call sil.splitIntervalList {

--- a/definitions/subworkflows/pindel.wdl
+++ b/definitions/subworkflows/pindel.wdl
@@ -23,7 +23,7 @@ workflow pindel {
     String normal_sample_name
     Int insert_size = 400
     Int scatter_count = 50
-    Float fp_min_var_freq
+    Float? fp_min_var_freq
   }
 
   call siltb.splitIntervalListToBed {

--- a/definitions/subworkflows/pindel.wdl
+++ b/definitions/subworkflows/pindel.wdl
@@ -23,6 +23,7 @@ workflow pindel {
     String normal_sample_name
     Int insert_size = 400
     Int scatter_count = 50
+    Float fp_min_var_freq
   }
 
   call siltb.splitIntervalListToBed {
@@ -88,7 +89,8 @@ workflow pindel {
     vcf=reindex.indexed_vcf,
     vcf_tbi=reindex.indexed_vcf_tbi,
     variant_caller="pindel",
-    sample_name=tumor_sample_name
+    sample_name=tumor_sample_name,
+    fp_min_var_freq=fp_min_var_freq
   }
 
   output {

--- a/definitions/subworkflows/strelka_and_post_processing.wdl
+++ b/definitions/subworkflows/strelka_and_post_processing.wdl
@@ -30,7 +30,7 @@ workflow strelkaAndPostProcessing {
     File? call_regions
     File? call_regions_tbi
 
-    Float fp_min_var_freq
+    Float? fp_min_var_freq
   }
 
   call s.strelka {

--- a/definitions/subworkflows/strelka_and_post_processing.wdl
+++ b/definitions/subworkflows/strelka_and_post_processing.wdl
@@ -29,6 +29,8 @@ workflow strelkaAndPostProcessing {
 
     File? call_regions
     File? call_regions_tbi
+
+    Float fp_min_var_freq
   }
 
   call s.strelka {
@@ -96,7 +98,8 @@ workflow strelkaAndPostProcessing {
     vcf=regionFilter.filtered_vcf,
     vcf_tbi=regionFilter.filtered_vcf_tbi,
     sample_name=tumor_sample_name,
-    variant_caller="strelka"
+    variant_caller="strelka",
+    fp_min_var_freq=fp_min_var_freq
   }
 
   output {

--- a/definitions/subworkflows/varscan.wdl
+++ b/definitions/subworkflows/varscan.wdl
@@ -17,10 +17,10 @@ workflow varscan {
 
     File? roi_bed
 
-    Int strand_filter
-    Int min_coverage
-    Float varscan_min_var_freq
-    Float p_value
+    Int? strand_filter
+    Int? min_coverage
+    Float? varscan_min_var_freq
+    Float? p_value
     Float? max_normal_freq
   }
 

--- a/definitions/subworkflows/varscan.wdl
+++ b/definitions/subworkflows/varscan.wdl
@@ -17,10 +17,10 @@ workflow varscan {
 
     File? roi_bed
 
-    Int strand_filter = 0
-    Int min_coverage = 8
-    Float min_var_freq = 0.1
-    Float p_value = 0.99
+    Int strand_filter
+    Int min_coverage
+    Float varscan_min_var_freq
+    Float p_value
     Float? max_normal_freq
   }
 
@@ -36,7 +36,7 @@ workflow varscan {
     roi_bed=roi_bed,
     strand_filter=strand_filter,
     min_coverage=min_coverage,
-    min_var_freq=min_var_freq,
+    varscan_min_var_freq=varscan_min_var_freq,
     p_value=p_value
   }
 
@@ -51,7 +51,6 @@ workflow varscan {
     variants=somatic.indels,
     max_normal_freq=max_normal_freq
   }
-
 
   output {
     # somatic

--- a/definitions/subworkflows/varscan_germline.wdl
+++ b/definitions/subworkflows/varscan_germline.wdl
@@ -13,11 +13,11 @@ workflow varscanGermline {
     File reference_fai
     File reference_dict
     File interval_list
-    Int strand_filter
-    Int min_coverage
-    Float varscan_min_var_freq
-    Int min_reads
-    Float p_value
+    Int? strand_filter
+    Int? min_coverage
+    Float? varscan_min_var_freq
+    Int? min_reads
+    Float? p_value
     String sample_name
   }
 

--- a/definitions/subworkflows/varscan_germline.wdl
+++ b/definitions/subworkflows/varscan_germline.wdl
@@ -13,11 +13,12 @@ workflow varscanGermline {
     File reference_fai
     File reference_dict
     File interval_list
-    Int strand_filter = 0
-    Int min_coverage = 8
-    Float min_var_freq = 0.1
-    Int min_reads = 2
-    Float p_value = 0.99
+    Int strand_filter
+    Int min_coverage
+    Float varscan_min_var_freq
+    Int min_reads
+    Float p_value
+    Fooat fp_min_var_freq
     String sample_name
   }
 
@@ -36,7 +37,7 @@ workflow varscanGermline {
     roi_bed=intervalsToBed.interval_bed,
     strand_filter=strand_filter,
     min_coverage=min_coverage,
-    min_var_freq=min_var_freq,
+    varscan_min_var_freq=varscan_min_var_freq,
     min_reads=min_reads,
     p_value=p_value,
     sample_name=sample_name
@@ -58,7 +59,7 @@ workflow varscanGermline {
     vcf_tbi=bgzipAndIndex.indexed_vcf_tbi,
     variant_caller="varscan",
     sample_name=sample_name,
-    min_var_freq=min_var_freq
+    fp_min_var_freq=fp_min_var_freq
   }
 
   output {

--- a/definitions/subworkflows/varscan_germline.wdl
+++ b/definitions/subworkflows/varscan_germline.wdl
@@ -18,7 +18,6 @@ workflow varscanGermline {
     Float varscan_min_var_freq
     Int min_reads
     Float p_value
-    Fooat fp_min_var_freq
     String sample_name
   }
 
@@ -59,7 +58,7 @@ workflow varscanGermline {
     vcf_tbi=bgzipAndIndex.indexed_vcf_tbi,
     variant_caller="varscan",
     sample_name=sample_name,
-    fp_min_var_freq=fp_min_var_freq
+    fp_min_var_freq=varscan_min_var_freq
   }
 
   output {

--- a/definitions/subworkflows/varscan_pre_and_post_processing.wdl
+++ b/definitions/subworkflows/varscan_pre_and_post_processing.wdl
@@ -26,10 +26,10 @@ workflow varscanPreAndPostProcessing {
 
     File interval_list
 
-    Int strand_filter
-    Int min_coverage
-    Float varscan_min_var_freq
-    Float p_value
+    Int? strand_filter
+    Int? min_coverage
+    Float? varscan_min_var_freq
+    Float? p_value
     Float? max_normal_freq
     Int scatter_count = 50
   }

--- a/definitions/subworkflows/varscan_pre_and_post_processing.wdl
+++ b/definitions/subworkflows/varscan_pre_and_post_processing.wdl
@@ -29,7 +29,6 @@ workflow varscanPreAndPostProcessing {
     Int strand_filter
     Int min_coverage
     Float varscan_min_var_freq
-    Float fp_min_var_freq
     Float p_value
     Float? max_normal_freq
     Int scatter_count = 50
@@ -155,7 +154,7 @@ workflow varscanPreAndPostProcessing {
     bam_bai=tumor_bam_bai,
     vcf=index.indexed_vcf,
     vcf_tbi=index.indexed_vcf_tbi,
-    fp_min_var_freq=fp_min_var_freq,
+    fp_min_var_freq=varscan_min_var_freq,
     sample_name=tumor_sample_name,
     variant_caller="varscan"
   }

--- a/definitions/subworkflows/varscan_pre_and_post_processing.wdl
+++ b/definitions/subworkflows/varscan_pre_and_post_processing.wdl
@@ -26,10 +26,11 @@ workflow varscanPreAndPostProcessing {
 
     File interval_list
 
-    Int strand_filter = 0
-    Int min_coverage = 8
-    Float min_var_freq = 0.1
-    Float p_value = 0.99
+    Int strand_filter
+    Int min_coverage
+    Float varscan_min_var_freq
+    Float fp_min_var_freq
+    Float p_value
     Float? max_normal_freq
     Int scatter_count = 50
   }
@@ -57,7 +58,7 @@ workflow varscanPreAndPostProcessing {
       roi_bed=intervalsToBed.interval_bed,
       strand_filter=strand_filter,
       min_coverage=min_coverage,
-      min_var_freq=min_var_freq,
+      varscan_min_var_freq=varscan_min_var_freq,
       p_value=p_value,
       max_normal_freq=max_normal_freq
     }
@@ -154,7 +155,7 @@ workflow varscanPreAndPostProcessing {
     bam_bai=tumor_bam_bai,
     vcf=index.indexed_vcf,
     vcf_tbi=index.indexed_vcf_tbi,
-    min_var_freq=min_var_freq,
+    fp_min_var_freq=fp_min_var_freq,
     sample_name=tumor_sample_name,
     variant_caller="varscan"
   }

--- a/definitions/tools/filter_vcf_somatic_llr.wdl
+++ b/definitions/tools/filter_vcf_somatic_llr.wdl
@@ -3,9 +3,9 @@ version 1.0
 task filterVcfSomaticLlr {
   input {
     File vcf
-    Float threshold
     String tumor_sample_name
     String normal_sample_name
+    Float threshold = 5
     Float tumor_purity = 1
     Float normal_contamination_rate = 0
   }

--- a/definitions/tools/fp_filter.wdl
+++ b/definitions/tools/fp_filter.wdl
@@ -11,7 +11,7 @@ task fpFilter {
 
     String output_vcf_basename = "fpfilter"
     String sample_name = "TUMOR"
-    Float min_var_freq = 0.05
+    Float fp_min_var_freq = 0.05
   }
 
   Int space_needed_gb = 10 + round(size(vcf, "GB")*2 + size([reference, reference_fai, reference_dict, bam], "GB"))
@@ -26,7 +26,7 @@ task fpFilter {
 
   String output_vcf = output_vcf_basename + ".vcf"
   command <<<
-    /usr/bin/perl /usr/bin/fpfilter.pl --bam-readcount /usr/bin/bam-readcount --samtools /opt/samtools/bin/samtools --output ~{output_vcf} --reference ~{reference} --bam-file ~{bam} --vcf-file ~{vcf} --sample ~{sample_name} --min-var-freq ~{min_var_freq}
+    /usr/bin/perl /usr/bin/fpfilter.pl --bam-readcount /usr/bin/bam-readcount --samtools /opt/samtools/bin/samtools --output ~{output_vcf} --reference ~{reference} --bam-file ~{bam} --vcf-file ~{vcf} --sample ~{sample_name} --min-var-freq ~{fp_min_var_freq}
   >>>
 
   output {

--- a/definitions/tools/varscan_germline.wdl
+++ b/definitions/tools/varscan_germline.wdl
@@ -9,7 +9,7 @@ task varscanGermline {
     File reference_dict
     Int strand_filter = 0
     Int min_coverage = 8
-    Float varscan_min_var_freq = 0.1
+    Float varscan_min_var_freq = 0.05
     Int min_reads = 2
     Float p_value = 0.99
     String sample_name

--- a/definitions/tools/varscan_germline.wdl
+++ b/definitions/tools/varscan_germline.wdl
@@ -9,7 +9,7 @@ task varscanGermline {
     File reference_dict
     Int strand_filter = 0
     Int min_coverage = 8
-    Float min_var_freq = 0.1
+    Float varscan_min_var_freq = 0.1
     Int min_reads = 2
     Float p_value = 0.99
     String sample_name
@@ -33,7 +33,7 @@ task varscanGermline {
     ~{reference} \
     ~{strand_filter} \
     ~{min_coverage} \
-    ~{min_var_freq} \
+    ~{varscan_min_var_freq} \
     ~{min_reads} \
     ~{p_value} \
     ~{sample_name} \

--- a/definitions/tools/varscan_somatic.wdl
+++ b/definitions/tools/varscan_somatic.wdl
@@ -14,7 +14,7 @@ task varscanSomatic {
 
     Int strand_filter = 0
     Int min_coverage = 8
-    Float varscan_min_var_freq = 0.1
+    Float varscan_min_var_freq = 0.05
     Float p_value = 0.99
     File? roi_bed
   }

--- a/definitions/tools/varscan_somatic.wdl
+++ b/definitions/tools/varscan_somatic.wdl
@@ -14,7 +14,7 @@ task varscanSomatic {
 
     Int strand_filter = 0
     Int min_coverage = 8
-    Float min_var_freq = 0.1
+    Float varscan_min_var_freq = 0.1
     Float p_value = 0.99
     File? roi_bed
   }
@@ -54,7 +54,7 @@ task varscanSomatic {
     "output" \
     --strand-filter "~{strand_filter}" \
     --min-coverage "~{min_coverage}" \
-    --min-var-freq "~{min_var_freq}" \
+    --min-var-freq "~{varscan_min_var_freq}" \
     --p-value "~{p_value}" \
     --mpileup 1 \
     --output-vcf
@@ -80,7 +80,7 @@ workflow wf {
 
     Int strand_filter
     Int min_coverage
-    Float min_var_freq
+    Float varscan_min_var_freq
     Float p_value
     File? roi_bed
   }
@@ -96,7 +96,7 @@ workflow wf {
     normal_bam_bai=normal_bam_bai,
     strand_filter=strand_filter,
     min_coverage=min_coverage,
-    min_var_freq=min_var_freq,
+    varscan_min_var_freq=varscan_min_var_freq,
     p_value=p_value,
     roi_bed=roi_bed
   }

--- a/definitions/tools/varscan_somatic.wdl
+++ b/definitions/tools/varscan_somatic.wdl
@@ -78,10 +78,10 @@ workflow wf {
     File normal_bam
     File normal_bam_bai
 
-    Int strand_filter = 0
-    Int min_coverage = 8
-    Float min_var_freq = 0.1
-    Float p_value = 0.99
+    Int strand_filter
+    Int min_coverage
+    Float min_var_freq
+    Float p_value
     File? roi_bed
   }
 

--- a/definitions/tumor_only_detect_variants.wdl
+++ b/definitions/tumor_only_detect_variants.wdl
@@ -38,8 +38,6 @@ workflow tumorOnlyDetectVariants {
     Float varscan_p_value
     Float maximum_population_allele_frequency = 0.001
 
-    Float fp_min_var_freq
-
     File vep_cache_dir_zip
     String vep_ensembl_assembly
     String vep_ensembl_version
@@ -76,7 +74,6 @@ workflow tumorOnlyDetectVariants {
     varscan_min_var_freq=varscan_min_var_freq,
     min_reads=varscan_min_reads,
     p_value=varscan_p_value,
-    fp_min_var_freq=fp_min_var_freq,
     sample_name=sample_name
   }
 

--- a/definitions/tumor_only_detect_variants.wdl
+++ b/definitions/tumor_only_detect_variants.wdl
@@ -38,6 +38,8 @@ workflow tumorOnlyDetectVariants {
     Float varscan_p_value
     Float maximum_population_allele_frequency = 0.001
 
+    Float fp_min_var_freq
+
     File vep_cache_dir_zip
     String vep_ensembl_assembly
     String vep_ensembl_version
@@ -71,9 +73,10 @@ workflow tumorOnlyDetectVariants {
     interval_list=roi_intervals,
     strand_filter=varscan_strand_filter,
     min_coverage=varscan_min_coverage,
-    min_var_freq=varscan_min_var_freq,
+    varscan_min_var_freq=varscan_min_var_freq,
     min_reads=varscan_min_reads,
     p_value=varscan_p_value,
+    fp_min_var_freq=fp_min_var_freq,
     sample_name=sample_name
   }
 

--- a/definitions/tumor_only_detect_variants.wdl
+++ b/definitions/tumor_only_detect_variants.wdl
@@ -31,11 +31,11 @@ workflow tumorOnlyDetectVariants {
     String gnomad_field_name = "gnomADe_AF"  # only change with gnomad_filter_annotation
     File roi_intervals
 
-    Int varscan_strand_filter
-    Int varscan_min_coverage
-    Int varscan_min_reads
-    Float varscan_min_var_freq
-    Float varscan_p_value
+    Int? varscan_strand_filter
+    Int? varscan_min_coverage
+    Int? varscan_min_reads
+    Float? varscan_min_var_freq
+    Float? varscan_p_value
     Float maximum_population_allele_frequency = 0.001
 
     File vep_cache_dir_zip

--- a/definitions/tumor_only_detect_variants.wdl
+++ b/definitions/tumor_only_detect_variants.wdl
@@ -31,11 +31,11 @@ workflow tumorOnlyDetectVariants {
     String gnomad_field_name = "gnomADe_AF"  # only change with gnomad_filter_annotation
     File roi_intervals
 
-    Int varscan_strand_filter = 0
-    Int varscan_min_coverage = 8
-    Int varscan_min_reads = 2
-    Float varscan_min_var_freq = 0.1
-    Float varscan_p_value = 0.99
+    Int varscan_strand_filter
+    Int varscan_min_coverage
+    Int varscan_min_reads
+    Float varscan_min_var_freq
+    Float varscan_p_value
     Float maximum_population_allele_frequency = 0.001
 
     File vep_cache_dir_zip

--- a/definitions/tumor_only_exome.wdl
+++ b/definitions/tumor_only_exome.wdl
@@ -108,7 +108,6 @@ workflow tumorOnlyExome {
     varscan_min_var_freq=varscan_min_var_freq,
     varscan_p_value=varscan_p_value,
     varscan_min_reads=varscan_min_reads,
-    fp_min_var_freq=fp_min_var_freq,
     maximum_population_allele_frequency=maximum_population_allele_frequency,
     vep_cache_dir_zip=vep_cache_dir_zip,
     vep_ensembl_assembly=vep_ensembl_assembly,

--- a/definitions/tumor_only_exome.wdl
+++ b/definitions/tumor_only_exome.wdl
@@ -34,11 +34,11 @@ workflow tumorOnlyExome {
     File omni_vcf_tbi
     String picard_metric_accumulation_level
     Int target_interval_padding = 100
-    Int varscan_strand_filter = 0
-    Int varscan_min_coverage = 8
-    Float varscan_min_var_freq = 0.1
-    Float varscan_p_value = 0.99
-    Int varscan_min_reads = 2
+    Int varscan_strand_filter
+    Int varscan_min_coverage
+    Float varscan_min_var_freq
+    Float varscan_p_value
+    Int varscan_min_reads
     Float maximum_population_allele_frequency = 0.001
 
     File vep_cache_dir_zip

--- a/definitions/tumor_only_exome.wdl
+++ b/definitions/tumor_only_exome.wdl
@@ -39,6 +39,7 @@ workflow tumorOnlyExome {
     Float varscan_min_var_freq
     Float varscan_p_value
     Int varscan_min_reads
+    Float fp_min_var_freq
     Float maximum_population_allele_frequency = 0.001
 
     File vep_cache_dir_zip
@@ -107,6 +108,7 @@ workflow tumorOnlyExome {
     varscan_min_var_freq=varscan_min_var_freq,
     varscan_p_value=varscan_p_value,
     varscan_min_reads=varscan_min_reads,
+    fp_min_var_freq=fp_min_var_freq,
     maximum_population_allele_frequency=maximum_population_allele_frequency,
     vep_cache_dir_zip=vep_cache_dir_zip,
     vep_ensembl_assembly=vep_ensembl_assembly,

--- a/definitions/tumor_only_exome.wdl
+++ b/definitions/tumor_only_exome.wdl
@@ -34,12 +34,12 @@ workflow tumorOnlyExome {
     File omni_vcf_tbi
     String picard_metric_accumulation_level
     Int target_interval_padding = 100
-    Int varscan_strand_filter
-    Int varscan_min_coverage
-    Float varscan_min_var_freq
-    Float varscan_p_value
-    Int varscan_min_reads
-    Float fp_min_var_freq
+    Int? varscan_strand_filter
+    Int? varscan_min_coverage
+    Float? varscan_min_var_freq
+    Float? varscan_p_value
+    Int? varscan_min_reads
+    Float? fp_min_var_freq
     Float maximum_population_allele_frequency = 0.001
 
     File vep_cache_dir_zip

--- a/definitions/tumor_only_wgs.wdl
+++ b/definitions/tumor_only_wgs.wdl
@@ -58,9 +58,9 @@ workflow tumorOnlyWgs {
     Array[String] variants_to_table_fields = ["CHROM", "POS", "ID", "REF", "ALT", "set", "AC", "AF"]
     Array[String] variants_to_table_genotype_fields = ["GT", "AD"]
     Array[String] vep_to_table_fields = ["HGVSc", "HGVSp"]
-    Int varscan_min_coverage
-    Float varscan_min_var_freq
-    Int varscan_min_reads
+    Int? varscan_min_coverage
+    Float? varscan_min_var_freq
+    Int? varscan_min_reads
     Float maximum_population_allele_frequency = 0.001
 }
 

--- a/definitions/tumor_only_wgs.wdl
+++ b/definitions/tumor_only_wgs.wdl
@@ -61,6 +61,7 @@ workflow tumorOnlyWgs {
     Int varscan_min_coverage
     Float varscan_min_var_freq
     Int varscan_min_reads
+    Float fp_min_var_freq
     Float maximum_population_allele_frequency = 0.001
 }
 
@@ -102,6 +103,7 @@ workflow tumorOnlyWgs {
     varscan_min_coverage=varscan_min_coverage,
     varscan_min_var_freq=varscan_min_var_freq,
     varscan_min_reads=varscan_min_reads,
+    fp_min_var_freq=fp_min_var_freq,
     maximum_population_allele_frequency=maximum_population_allele_frequency,
     vep_cache_dir_zip=vep_cache_dir_zip,
     synonyms_file=synonyms_file,

--- a/definitions/tumor_only_wgs.wdl
+++ b/definitions/tumor_only_wgs.wdl
@@ -61,7 +61,6 @@ workflow tumorOnlyWgs {
     Int varscan_min_coverage
     Float varscan_min_var_freq
     Int varscan_min_reads
-    Float fp_min_var_freq
     Float maximum_population_allele_frequency = 0.001
 }
 
@@ -103,7 +102,6 @@ workflow tumorOnlyWgs {
     varscan_min_coverage=varscan_min_coverage,
     varscan_min_var_freq=varscan_min_var_freq,
     varscan_min_reads=varscan_min_reads,
-    fp_min_var_freq=fp_min_var_freq,
     maximum_population_allele_frequency=maximum_population_allele_frequency,
     vep_cache_dir_zip=vep_cache_dir_zip,
     synonyms_file=synonyms_file,

--- a/definitions/tumor_only_wgs.wdl
+++ b/definitions/tumor_only_wgs.wdl
@@ -58,9 +58,9 @@ workflow tumorOnlyWgs {
     Array[String] variants_to_table_fields = ["CHROM", "POS", "ID", "REF", "ALT", "set", "AC", "AF"]
     Array[String] variants_to_table_genotype_fields = ["GT", "AD"]
     Array[String] vep_to_table_fields = ["HGVSc", "HGVSp"]
-    Int varscan_min_coverage = 8
-    Float varscan_min_var_freq = 0.05
-    Int varscan_min_reads = 2
+    Int varscan_min_coverage
+    Float varscan_min_var_freq
+    Int varscan_min_reads
     Float maximum_population_allele_frequency = 0.001
 }
 


### PR DESCRIPTION
This PR is related to issue https://github.com/wustl-oncology/analysis-wdls/issues/97 and is a competing PR with https://github.com/wustl-oncology/analysis-wdls/pull/104 by @Layth17.  

The purpose is to: 
- simplifying the specification of defaults for variant frequency and llr cutoffs throughout the pipeline. Confining the setting of defaults to the tool itself (and allowing override in a YAML by any pipeline that uses that tool).
- clarify variable names to make it more clear how varscan min_freq cutoffs are used compared to those used by fp_filter for strelka, mutect and pindel
- make sure that the varscan min_freq parameters are independent of those specified for strelka, mutect and pindel