### PR TITLE
moved the set -o lines under the ACCESS_TOKEN block

### DIFF
--- a/definitions/tools/varscan_somatic.wdl
+++ b/definitions/tools/varscan_somatic.wdl
@@ -25,6 +25,7 @@ task varscanSomatic {
   runtime {
     preemptible: 1
     maxRetries: 2
+
     memory: "12GB"
     cpu: 2
     docker: "mgibio/varscan-cwl:v2.4.2-samtools1.16.1"
@@ -32,16 +33,18 @@ task varscanSomatic {
   }
 
   command <<<
-    set -o errexit
-    set -o nounset
-    set -o pipefail
-
+ 
     ACCESS_TOKEN=$(wget -O - --header "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token?alt=text 2> /dev/null | grep access_token)
     if [[ "$ACCESS_TOKEN" == "access_token"* ]]; then
        # When the BAMs aren't localized in GCP, samtools needs this token to access them via gs:// URLs.
        export GCS_OAUTH_TOKEN=$(echo "$ACCESS_TOKEN" | cut -d ' ' -f 2 )
        echo "got token" ${GCS_OAUTH_TOKEN:0:5}
     fi
+
+    set -o errexit
+    set -o nounset
+    set -o pipefail
+
 
     /opt/samtools/bin/samtools mpileup --no-baq ~{if defined(roi_bed) then "-l ~{roi_bed}" else ""} -f "~{reference}" "~{normal_bam}" "~{tumor_bam}" | \
     java -jar /opt/varscan/VarScan.jar somatic /dev/stdin \


### PR DESCRIPTION
Attempting to run immuno on compute1 results in varscan failing. @tmooney suggested moving the set -o lines after the wget block. As of now, since errext and pipefail are set before wget, when the command is executed wget does not find the server and it causes a non-zero exit. I have tested this change and it appears that this fix allows varscan to execute successfully. 