### PR TITLE
changing localization_optional to false in mutect tool

### DIFF
--- a/definitions/tools/mutect.wdl
+++ b/definitions/tools/mutect.wdl
@@ -16,10 +16,10 @@ task mutect {
   }
 
   parameter_meta {
-    tumor_bam: { localization_optional: true }
-    tumor_bam_bai: { localization_optional: true }
-    normal_bam: { localization_optional: true }
-    normal_bam_bai: { localization_optional: true }
+    tumor_bam: { localization_optional: false }
+    tumor_bam_bai: { localization_optional: false }
+    normal_bam: { localization_optional: false }
+    normal_bam_bai: { localization_optional: false }
   }
 
   Float reference_size = size([reference, reference_fai, reference_dict], "GB")


### PR DESCRIPTION
Change `localization_optional:true` to false. 

https://github.com/wustl-oncology/analysis-wdls/blob/c89037d4164215c3d73f8fd766f63c92933dcfc2/definitions/tools/mutect.wdl#L19-L22
