### PR TITLE
increase memory resources to accommodate BigMHC

### DIFF
--- a/definitions/tools/pvacfuse.wdl
+++ b/definitions/tools/pvacfuse.wdl
@@ -36,7 +36,7 @@ task pvacfuse {
     preemptible: 1
     maxRetries: 2
     docker: "griffithlab/pvactools:4.3.0"
-    memory: "16GB"
+    memory: "32GB"
     cpu: n_threads
     disks: "local-disk ~{space_needed_gb} HDD"
   }

--- a/definitions/tools/pvacseq.wdl
+++ b/definitions/tools/pvacseq.wdl
@@ -54,7 +54,7 @@ task pvacseq {
   runtime {
     preemptible: 1
     maxRetries: 2
-    memory: "16GB"
+    memory: "32GB"
     cpu: n_threads
     docker: "griffithlab/pvactools:4.3.0"
     disks: "local-disk ~{space_needed_gb} HDD"


### PR DESCRIPTION
We have encountered consistent failures from BigMHC using 16GB and 8 cpus. This increase seems to resolve the issue. 