### PR TITLE
fix typo in naming of samples in vcf in strelka variant detection

### DIFF
--- a/definitions/detect_variants_nonhuman.wdl
+++ b/definitions/detect_variants_nonhuman.wdl
@@ -93,7 +93,7 @@ workflow detectVariantsNonhuman {
     exome_mode=strelka_exome_mode,
     cpu_reserved=strelka_cpu_reserved,
     normal_sample_name=normal_sample_name,
-    tumor_sample_name=normal_sample_name,
+    tumor_sample_name=tumor_sample_name,
     fp_min_var_freq=fp_min_var_freq
   }
 


### PR DESCRIPTION
Proposing a fix for issue: https://github.com/wustl-oncology/analysis-wdls/issues/155

This will correct a typo in strelka variant processing that we believe was impacting results from this variant caller for the non-human variant calling pipeline.