### PR TITLE
clarify two immuno inputs

### DIFF
--- a/definitions/immuno.wdl
+++ b/definitions/immuno.wdl
@@ -213,8 +213,11 @@ workflow immuno {
     Array[String]? clinical_mhc_classI_alleles
     Array[String]? clinical_mhc_classII_alleles
 
-    # --------- PVACseq Inputs -----------------------------------------
+    # --------- HLA Consensus Inputs -----------------------------------
+
     String hla_source_mode
+
+    # --------- PVACseq Inputs -----------------------------------------
     Int? readcount_minimum_base_quality
     Int? readcount_minimum_mapping_quality
     Array[String] prediction_algorithms
@@ -498,6 +501,7 @@ workflow immuno {
     run_reference_proteome_similarity=run_reference_proteome_similarity,
     peptide_fasta=peptide_fasta,
     n_threads=pvacseq_threads,
+    iedb_retries=iedb_retries,
     variants_to_table_fields=variants_to_table_fields,
     variants_to_table_genotype_fields=variants_to_table_genotype_fields,
     vep_to_table_fields=vep_to_table_fields,
@@ -521,7 +525,6 @@ workflow immuno {
     epitope_lengths_class_ii=epitope_lengths_class_ii,
     binding_threshold=binding_threshold,
     percentile_threshold=percentile_threshold,
-    iedb_retries=iedb_retries,
     keep_tmp_files=pvacfuse_keep_tmp_files,
     net_chop_method=net_chop_method,
     netmhc_stab=netmhc_stab,
@@ -534,6 +537,7 @@ workflow immuno {
     downstream_sequence_length=downstream_sequence_length,
     exclude_nas=exclude_nas,
     n_threads=pvacseq_threads,
+    iedb_retries=iedb_retries,
     read_support=pvacfuse_read_support,
     expn_val=pvacfuse_expn_val,
     allele_specific_binding_thresholds=allele_specific_binding_thresholds,

--- a/definitions/subworkflows/pvacseq.wdl
+++ b/definitions/subworkflows/pvacseq.wdl
@@ -52,6 +52,7 @@ workflow pvacseq {
     Boolean? netmhc_stab
     Boolean? run_reference_proteome_similarity
     Int? n_threads
+    Int? iedb_retries
     Array[String] variants_to_table_fields = ["CHROM", "POS", "ID", "REF", "ALT"]
     Array[String] variants_to_table_genotype_fields = ["GT", "AD", "AF", "DP", "RAD", "RAF", "RDP", "GX", "TX"]
     Array[String] vep_to_table_fields = ["HGVSc", "HGVSp"]
@@ -143,6 +144,7 @@ workflow pvacseq {
     run_reference_proteome_similarity=run_reference_proteome_similarity,
     peptide_fasta=peptide_fasta,
     n_threads=n_threads,
+    iedb_retries=iedb_retries,
     tumor_purity=tumor_purity,
     allele_specific_binding_thresholds=allele_specific_binding_thresholds,
     aggregate_inclusion_binding_threshold=aggregate_inclusion_binding_threshold,


### PR DESCRIPTION
Pass through iedb_retries variable to pvacseq and improve documentation of hla_source_mode.

The input variable `iedb_retries` could be used in tools/pvacseq.wdl and tools/pvacfuse.wdl.  However, in immuno.wdl, it was only getting passed through to pvacfuse. Fixing that.

The input variable `hla_source_mode` was being described as an input to pvacseq, which it is not.  Clarifying that. 