### PR TITLE
update to use new bam_readcount_helper image

### DIFF
--- a/definitions/tools/bam_readcount.wdl
+++ b/definitions/tools/bam_readcount.wdl
@@ -18,7 +18,7 @@ task bamReadcount {
   runtime {
     preemptible: 1
     maxRetries: 2
-    docker: "mgibio/bam_readcount_helper-cwl:1.1.1"
+    docker: "mgibio/bam_readcount_helper-cwl:1.2.1"
     memory: "16GB"
     disks: "local-disk ~{space_needed_gb} HDD"
   }


### PR DESCRIPTION
Update to use new helper image (1.2.1) with updates to: bam-readcount(1.0.1), samtools (1.21), and cyvcf2 (0.31.1)